### PR TITLE
Add Docker-based build system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+~output
+_build
+_devel
+_logs
+temp
+*.log
+XVM.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# XVM — Docker Build
+#
+# Builds XVM from source in a reproducible Linux environment.
+# Produces .wotmod (WG) and/or .mtmod (Lesta) in /build/~output/deploy/.
+#
+# Build:
+#   docker build --platform linux/amd64 -t xvm-build .
+#
+# Build a specific flavor:
+#   docker build --platform linux/amd64 --build-arg FLAVOR=lesta -t xvm-build .
+#
+# Extract artifacts:
+#   docker run --rm xvm-build cat /build/~output/deploy/*.wotmod > xvm.wotmod
+#
+# Or copy out:
+#   id=$(docker create xvm-build)
+#   docker cp "$id:/build/~output/deploy/" ./output/
+#   docker rm "$id"
+
+FROM ubuntu:20.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openjdk-11-jdk-headless \
+        python2.7 \
+        zip \
+        unzip \
+        patch \
+        curl \
+        ca-certificates \
+    && ln -sf /usr/bin/python2.7 /usr/bin/python2 \
+    && ln -sf /usr/bin/python2.7 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
+
+# Apache Royale 0.9.12
+RUN mkdir -p /opt/apache-royale \
+    && curl -fSL "https://dlcdn.apache.org/royale/0.9.12/binaries/apache-royale-0.9.12-bin-js-swf.zip" \
+        -o /tmp/royale.zip \
+    && unzip -q /tmp/royale.zip -d /opt/apache-royale/ \
+    && rm /tmp/royale.zip
+
+ENV ROYALE_HOME=/opt/apache-royale/royale-asjs
+
+# Verify tools
+RUN java -version \
+    && python2.7 --version \
+    && test -f "$ROYALE_HOME/js/lib/mxmlc.jar"
+
+# ---------------------------------------------------------------------------
+
+FROM base AS build
+
+ARG FLAVOR=wg
+ARG VERSION=
+
+WORKDIR /build
+COPY . /build/
+
+RUN python2.7 build.py --flavor=${FLAVOR} ${VERSION:+--version=${VERSION}}

--- a/build.py
+++ b/build.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 OpenWG Contributors
+"""
+XVM Build Orchestrator
+
+Data-driven Python equivalent of build.ps1 + library_*.psm1.
+Reads the same JSON config files used by the PowerShell build system,
+then delegates tool invocations to build_helpers.sh.
+
+Compatible with Python 2.7+ and Python 3.x.
+
+Requirements (provided by Dockerfile, or install locally):
+  - Java 8+           (Apache Royale compiler)
+  - Apache Royale 0.9.12
+  - Python 2.7        (.pyc compilation)
+  - patch, zip, unzip
+
+Usage:
+  python build.py                    # Build WG flavor
+  python build.py --flavor=lesta     # Build Lesta flavor
+  python build.py --flavor=all       # Build both flavors
+"""
+from __future__ import print_function
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+HELPERS = os.path.join(SCRIPT_DIR, 'build_helpers.sh')
+
+
+# ============================================================================
+# Tool discovery
+# ============================================================================
+
+def which(name):
+    """Find an executable on PATH (Python 2/3 compatible)."""
+    for d in os.environ.get('PATH', '').split(os.pathsep):
+        p = os.path.join(d, name)
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            return p
+    return None
+
+
+def find_royale():
+    """Locate the Apache Royale SDK root."""
+    candidates = [
+        os.environ.get('ROYALE_HOME', ''),
+        '/opt/apache-royale/royale-asjs',
+        '/opt/apache-royale',
+        '/opt/apache-royale-0.9.12-bin-js-swf/royale-asjs',
+        '/opt/apache-royale-0.9.12-bin-js-swf',
+    ]
+    for c in candidates:
+        if not c:
+            continue
+        if os.path.isfile(os.path.join(c, 'js/lib/mxmlc.jar')):
+            return c
+        sub = os.path.join(c, 'royale-asjs')
+        if os.path.isfile(os.path.join(sub, 'js/lib/mxmlc.jar')):
+            return sub
+    return None
+
+
+def find_python27():
+    """Find a Python 2.7 interpreter."""
+    for name in ('python2.7', 'python2', 'python'):
+        p = which(name)
+        if not p:
+            continue
+        try:
+            ver = subprocess.check_output([p, '--version'],
+                                          stderr=subprocess.STDOUT)
+            if b'2.7' in ver:
+                return p
+        except (subprocess.CalledProcessError, OSError):
+            continue
+    return None
+
+
+class Tools(object):
+    """Resolved build tool paths."""
+    def __init__(self):
+        if not which('java'):
+            fail("'java' not found in PATH")
+        if not which('zip'):
+            fail("'zip' not found in PATH")
+        if not which('patch'):
+            fail("'patch' not found in PATH")
+
+        self.royale_home = find_royale()
+        if not self.royale_home:
+            fail('Apache Royale SDK not found. Set ROYALE_HOME.')
+
+        self.python27 = find_python27()
+        if not self.python27:
+            fail('Python 2.7 is required for .pyc compilation.')
+
+        self.royale_config = os.path.join(
+            SCRIPT_DIR, 'src_build/royale_toolchain/xvm-config.xml')
+
+        self.rabcdasm_dir = os.path.join(
+            SCRIPT_DIR, 'src_build/bin/linux_amd64/rabcdasm')
+        if os.path.isdir(self.rabcdasm_dir):
+            for f in os.listdir(self.rabcdasm_dir):
+                fp = os.path.join(self.rabcdasm_dir, f)
+                if os.path.isfile(fp):
+                    os.chmod(fp, 0o755)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def fail(msg):
+    print('Error: %s' % msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def run_helper(command, args):
+    """Call a build_helpers.sh function."""
+    cmd = ['bash', HELPERS, command] + args
+    subprocess.check_call(cmd)
+
+
+def substitute(s, flavor, output_dir, src_dir):
+    """Replace <FLAVOR>, <OUTPUT>, <SRC> placeholders."""
+    return (s.replace('<FLAVOR>', flavor)
+             .replace('<OUTPUT>', output_dir)
+             .replace('<SRC>', src_dir))
+
+
+def expand_source_paths(paths, flavor, output_dir, src_dir):
+    """Resolve placeholders and expand trailing /* globs."""
+    result = []
+    for p in paths:
+        p = substitute(p, flavor, output_dir, src_dir)
+        if p.endswith('/*'):
+            base = p[:-2]
+            if os.path.isdir(base):
+                for name in sorted(os.listdir(base)):
+                    full = os.path.join(base, name)
+                    if os.path.isdir(full):
+                        result.append(full)
+            else:
+                result.append(p)
+        else:
+            result.append(p)
+    return result
+
+
+def find_json_files(root, filename):
+    """Recursively find all files matching filename under root, sorted."""
+    found = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if filename in filenames:
+            found.append(os.path.join(dirpath, filename))
+    return sorted(found)
+
+
+
+# ============================================================================
+# Component processors
+# ============================================================================
+
+def process_swfpatch(comp_dir, flavor, wotmod_path, tools):
+    """Process swfpatch.json files within a component."""
+    for spj in find_json_files(comp_dir, 'swfpatch.json'):
+        cfg = load_json(spj)
+        sp_flavor = cfg.get('flavor', '')
+        if sp_flavor and sp_flavor != flavor:
+            continue
+
+        sp_dir = os.path.dirname(spj)
+        print('    Processing swfpatch (%s): %s' % (flavor, sp_dir))
+
+        for item in cfg.get('build', []):
+            swf_file = item.get('file', '')
+            if not swf_file:
+                continue
+
+            patches_list = item.get('patches', [])
+            linkages_list = item.get('linkages', [])
+            install_dir = item.get('install_directory', '')
+
+            # Resolve full paths for patches
+            full_patches = ','.join(
+                os.path.join(sp_dir, p) for p in patches_list)
+            linkages = ','.join(linkages_list)
+
+            input_swf = os.path.join(sp_dir, swf_file)
+            output_swf = os.path.join(wotmod_path, install_dir,
+                                      os.path.basename(swf_file))
+
+            args = [
+                '--input-swf', input_swf,
+                '--output-swf', output_swf,
+                '--patches', full_patches,
+                '--linkages', linkages,
+                '--rabcdasm-dir', tools.rabcdasm_dir,
+            ]
+            run_helper('patch_wg_swf', args)
+
+
+def process_actionscript(comp_dir, flavor, swf_out_dir, wotmod_path, tools):
+    """Process actionscript.json files within a component."""
+    for asj in sorted(find_json_files(comp_dir, 'actionscript.json')):
+        cfg = load_json(asj)
+        as_dir = os.path.dirname(asj)
+
+        print('    Processing actionscript: %s' % as_dir)
+
+        for item in cfg.get('build', []):
+            # Flavor filter
+            item_flavors = item.get('flavors')
+            if item_flavors and flavor not in item_flavors:
+                continue
+
+            name = item.get('name', '')
+            build_type = item.get('type', '')
+            if not name or not build_type:
+                continue
+
+            # Resolve placeholders
+            target = substitute(
+                item.get('target', ''), flavor, swf_out_dir, as_dir)
+            include_classes = ' '.join(item.get('include_classes', []))
+            ext_libs = ','.join(
+                substitute(p, flavor, swf_out_dir, as_dir)
+                for p in item.get('external_library_path', []))
+            inc_libs = ','.join(
+                substitute(p, flavor, swf_out_dir, as_dir)
+                for p in item.get('include_libraries', []))
+            install_dir = substitute(
+                item.get('install_directory', ''), flavor, swf_out_dir, as_dir)
+            patches = [
+                substitute(p, flavor, swf_out_dir, as_dir)
+                for p in item.get('patches', [])]
+
+            # source_path: default to {as_dir}/{name}/ if not specified
+            raw_sp = item.get('source_path')
+            if raw_sp:
+                source_paths = expand_source_paths(
+                    raw_sp, flavor, swf_out_dir, as_dir)
+            else:
+                source_paths = [os.path.join(as_dir, name)]
+            source_path = ','.join(source_paths)
+
+            if build_type == 'swc':
+                outfile = os.path.join(swf_out_dir, 'swc', name + '.swc')
+                args = [
+                    '--name', name,
+                    '--output', outfile,
+                    '--include-classes', include_classes,
+                    '--source-path', source_path,
+                    '--external-library-path', ext_libs,
+                    '--include-libraries', inc_libs,
+                    '--royale-home', tools.royale_home,
+                    '--config', tools.royale_config,
+                    '--flavor', flavor,
+                ]
+                run_helper('build_swc', args)
+
+                # Post-build SWC patches (e.g. xfw_access)
+                if patches:
+                    run_helper('patch_swc', [
+                        '--swc-file', outfile,
+                        '--patches', ','.join(patches),
+                        '--rabcdasm-dir', tools.rabcdasm_dir,
+                    ])
+
+            elif build_type == 'swf':
+                outfile = os.path.join(swf_out_dir, 'swf', name + '.swf')
+                args = [
+                    '--name', name,
+                    '--output', outfile,
+                    '--target', target,
+                    '--source-path', source_path,
+                    '--external-library-path', ext_libs,
+                    '--include-libraries', inc_libs,
+                    '--royale-home', tools.royale_home,
+                    '--config', tools.royale_config,
+                    '--flavor', flavor,
+                ]
+                run_helper('build_swf', args)
+
+                # Install SWF to wotmod staging
+                if install_dir:
+                    dest = os.path.join(wotmod_path, install_dir)
+                    if not os.path.isdir(dest):
+                        os.makedirs(dest)
+                    shutil.copy2(outfile, dest)
+                    print('      -> %s/' % install_dir)
+
+
+def process_python(comp_dir, comp_prefix, wotmod_path, tools):
+    """Process python.json files within a component."""
+    for pyj in find_json_files(comp_dir, 'python.json'):
+        cfg = load_json(pyj)
+        py_dir = os.path.dirname(pyj)
+
+        # Resolve install prefix
+        install_prefix = cfg.get('install_prefix', '')
+        if install_prefix:
+            install_prefix = install_prefix.replace(
+                '{root}', 'res/mods/openwg_packages/%s/' % comp_prefix)
+        else:
+            install_prefix = 'res/mods/openwg_packages/%s/' % comp_prefix
+
+        py_out = os.path.join(wotmod_path, install_prefix)
+
+        # Run generators
+        for gen_script in cfg.get('generators', []):
+            gen_path = os.path.join(py_dir, gen_script)
+            if os.path.isfile(gen_path):
+                print('    [GEN] %s' % gen_script)
+                subprocess.check_call(
+                    [tools.python27, gen_path, py_dir, py_out])
+
+        print('    [PY] %s -> %s' % (os.path.basename(py_dir), install_prefix))
+        run_helper('compile_python_dir', [
+            '--src-dir', py_dir,
+            '--dst-dir', py_out,
+            '--python27', tools.python27,
+        ])
+
+
+def process_assets(comp_dir, comp_prefix, wotmod_path):
+    """Process assets.json files within a component."""
+    for aj in find_json_files(comp_dir, 'assets.json'):
+        cfg = load_json(aj)
+        assets_dir = os.path.dirname(aj)
+
+        install_prefix = cfg.get('install_prefix', 'res/')
+        install_prefix = install_prefix.replace(
+            '{root}', 'res/mods/openwg_packages/%s/' % comp_prefix)
+
+        dest = os.path.join(wotmod_path, install_prefix)
+        if not os.path.isdir(dest):
+            os.makedirs(dest)
+
+        count = 0
+        for f in sorted(os.listdir(assets_dir)):
+            fp = os.path.join(assets_dir, f)
+            if not os.path.isfile(fp):
+                continue
+            if f.endswith('.json'):
+                continue
+            shutil.copy2(fp, dest)
+            count += 1
+        print('    [ASSETS] %d files -> %s' % (count, install_prefix))
+
+
+def generate_package_meta(comp_json_path, version, owg_out):
+    """Write package.json metadata and stub __init__.pyc."""
+    comp = load_json(comp_json_path)
+    comp_id = comp.get('id', '')
+    if not comp_id:
+        return
+
+    if not os.path.isdir(owg_out):
+        os.makedirs(owg_out)
+
+    meta = {
+        'id': comp_id,
+        'name': '',
+        'description': '',
+        'version': version,
+        'dependencies': comp.get('dependencies', []),
+        'features': comp.get('features', []),
+        'features_provide': comp.get('features_provide', []),
+        'url': '',
+        'url_update': '',
+        'wot_versions': ['0.0.0.0'],
+        'wot_versions_strategy': 'allow_newer',
+    }
+    meta_path = os.path.join(owg_out, 'package.json')
+    with open(meta_path, 'w') as f:
+        json.dump(meta, f, indent=4)
+
+
+def generate_stub_init(owg_out, python27):
+    """Generate a stub __init__.pyc if one doesn't exist."""
+    init_pyc = os.path.join(owg_out, '__init__.pyc')
+    init_py = os.path.join(owg_out, '__init__.py')
+    if os.path.exists(init_pyc) or os.path.exists(init_py):
+        return
+
+    with open(init_py, 'w') as f:
+        f.write("""\
+__initialized = False
+
+def owg_module_init():
+    global __initialized
+    __initialized = True
+
+def owg_module_fini():
+    global __initialized
+    __initialized = False
+
+def owg_module_loaded():
+    global __initialized
+    return __initialized
+
+def owg_module_event(eventName, *args, **kwargs):
+    pass
+""")
+
+    subprocess.check_call([python27, '-m', 'py_compile', init_py])
+    os.remove(init_py)
+
+
+# ============================================================================
+# Build pipeline
+# ============================================================================
+
+def build_flavor(flavor, tools, version_override=None):
+    """Run the full build for a single flavor."""
+    if flavor == 'wg':
+        pass
+    elif flavor == 'lesta':
+        pass
+    else:
+        fail("Unknown flavor '%s'" % flavor)
+
+    src_dir = os.path.join(SCRIPT_DIR, 'src')
+    output_dir = os.path.join(SCRIPT_DIR, '~output')
+
+    # Read version from build.json, allow override via --version
+    build_cfg = load_json(os.path.join(SCRIPT_DIR, 'build.json'))
+    version = version_override or build_cfg.get('game_version_%s' % flavor, '0.0.0')
+
+    # Per-flavor directories
+    swf_out_dir = os.path.join(output_dir, 'swf_%s' % flavor)
+    wotmod_path = os.path.join(output_dir, 'wotmod')
+    deploy_dir = os.path.join(output_dir, 'deploy')
+
+    for d in [swf_out_dir, os.path.join(swf_out_dir, 'swc'),
+              os.path.join(swf_out_dir, 'swf'), wotmod_path, deploy_dir]:
+        if not os.path.isdir(d):
+            os.makedirs(d)
+
+    # Read root package config
+    pkg_cfg = load_json(os.path.join(src_dir, 'package.json'))
+    pkg_id = pkg_cfg.get('id', 'com.modxvm.xvm')
+    pkg_name = pkg_cfg.get('name', 'XVM')
+
+    print('')
+    print('=' * 64)
+    print('  XVM Build  --  flavor: %s' % flavor)
+    print('  Royale:  %s' % tools.royale_home)
+    print('  Python:  %s' % tools.python27)
+    print('  Output:  %s' % output_dir)
+    print('=' * 64)
+    print('')
+
+    # Discover components
+    print('=== Processing components ===')
+    print('')
+
+    for comp_json in find_json_files(src_dir, 'component.json'):
+        comp = load_json(comp_json)
+        comp_id = comp.get('id', '')
+        if not comp_id:
+            continue
+
+        comp_dir = os.path.dirname(comp_json)
+        comp_prefix = comp.get('prefix', os.path.basename(comp_dir))
+
+        print('  Component: %s' % comp_id)
+
+        owg_out = os.path.join(
+            wotmod_path, 'res/mods/openwg_packages', comp_prefix)
+
+        # --- swfpatch ---
+        process_swfpatch(comp_dir, flavor, wotmod_path, tools)
+
+        # --- actionscript ---
+        process_actionscript(
+            comp_dir, flavor, swf_out_dir, wotmod_path, tools)
+
+        # --- python ---
+        process_python(comp_dir, comp_prefix, wotmod_path, tools)
+
+        # --- assets ---
+        process_assets(comp_dir, comp_prefix, wotmod_path)
+
+        # --- package.json metadata + stub __init__ ---
+        generate_package_meta(comp_json, version, owg_out)
+        generate_stub_init(owg_out, tools.python27)
+
+        print('')
+
+    # Package .wotmod / .mtmod
+    print('=== Packaging ===')
+
+    meta_xml = os.path.join(wotmod_path, 'meta.xml')
+    with open(meta_xml, 'w') as f:
+        f.write('<root>\n')
+        f.write('    <id>%s</id>\n' % pkg_id)
+        f.write('    <name>%s</name>\n' % pkg_name)
+        f.write('    <description></description>\n')
+        f.write('    <version>%s</version>\n' % version)
+        f.write('</root>\n')
+
+    ext = 'mtmod' if flavor == 'lesta' else 'wotmod'
+    out_file = os.path.join(
+        deploy_dir, '%s_%s.%s' % (pkg_id, version, ext))
+
+    run_helper('package_wotmod', [
+        '--staging-dir', wotmod_path,
+        '--output-file', out_file,
+    ])
+
+    size = os.path.getsize(out_file)
+    print('')
+    print('[DONE] %s  (%d bytes)' % (out_file, size))
+    print('')
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    flavor = 'wg'
+    version_override = None
+    for arg in sys.argv[1:]:
+        if arg.startswith('--flavor='):
+            flavor = arg.split('=', 1)[1]
+        elif arg.startswith('--version='):
+            version_override = arg.split('=', 1)[1]
+        elif arg in ('--help', '-h'):
+            print('Usage: python build.py [--flavor=wg|lesta|all] [--version=X.Y.Z]')
+            sys.exit(0)
+        else:
+            fail('Unknown argument: %s' % arg)
+
+    tools = Tools()
+
+    # Clean previous build
+    output_dir = os.path.join(SCRIPT_DIR, '~output')
+    for d in ('build', 'wotmod', 'deploy'):
+        p = os.path.join(output_dir, d)
+        if os.path.isdir(p):
+            shutil.rmtree(p)
+
+    if flavor == 'all':
+        for d in ('swf_wg', 'wotmod'):
+            p = os.path.join(output_dir, d)
+            if os.path.isdir(p):
+                shutil.rmtree(p)
+        build_flavor('wg', tools, version_override)
+
+        for d in ('swf_lesta', 'wotmod'):
+            p = os.path.join(output_dir, d)
+            if os.path.isdir(p):
+                shutil.rmtree(p)
+        build_flavor('lesta', tools, version_override)
+
+        print('=== Both flavors built ===')
+    else:
+        build_flavor(flavor, tools, version_override)
+
+    print('=== Build Complete ===')
+
+
+if __name__ == '__main__':
+    main()

--- a/build_helpers.sh
+++ b/build_helpers.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# XVM — Bash Build Helpers
+#
+# Reusable shell functions for AS3 compilation, SWF/SWC patching,
+# Python compilation, and .wotmod packaging.
+#
+# Called by build.py via:  bash build_helpers.sh <command> [args...]
+#
+# Each function accepts named arguments (--key value) so the interface
+# is self-documenting and order-independent.
+
+set -euo pipefail
+
+
+# ============================================================================
+# build_swc — compile an AS3 SWC via Apache Royale (compc)
+# ============================================================================
+#
+# Args:
+#   --name              Build artifact name (for logging)
+#   --output            Output .swc path
+#   --include-classes   Space-separated class names (may contain $AppLinks)
+#   --source-path       Comma-separated source directories
+#   --external-library-path  Comma-separated .swc paths
+#   --include-libraries Comma-separated .swc paths (optional)
+#   --royale-home       Royale SDK root
+#   --config            Royale config XML path
+#   --flavor            wg or lesta
+#
+build_swc() {
+    local name="" output="" include_classes="" source_path="" ext_libs="" inc_libs=""
+    local royale_home="" config="" flavor=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --name)              name="$2"; shift 2 ;;
+            --output)            output="$2"; shift 2 ;;
+            --include-classes)   include_classes="$2"; shift 2 ;;
+            --source-path)       source_path="$2"; shift 2 ;;
+            --external-library-path) ext_libs="$2"; shift 2 ;;
+            --include-libraries) inc_libs="$2"; shift 2 ;;
+            --royale-home)       royale_home="$2"; shift 2 ;;
+            --config)            config="$2"; shift 2 ;;
+            --flavor)            flavor="$2"; shift 2 ;;
+            *) echo "build_swc: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    local is_wg=false is_lesta=false
+    [[ "$flavor" == "wg" ]] && is_wg=true
+    [[ "$flavor" == "lesta" ]] && is_lesta=true
+
+    mkdir -p "$(dirname "$output")"
+
+    echo "    [SWC] $name"
+
+    local -a args=()
+
+    # include-classes (space-separated, may contain $AppLinks)
+    if [[ -n "$include_classes" ]]; then
+        # Word-split on spaces to produce separate arguments
+        # shellcheck disable=SC2086
+        args+=("-include-classes" $include_classes)
+    fi
+
+    # source-path (comma-separated → multiple -source-path flags)
+    if [[ -n "$source_path" ]]; then
+        local first=true
+        IFS=',' read -ra sp_arr <<< "$source_path"
+        for sp in "${sp_arr[@]}"; do
+            [[ -z "$sp" ]] && continue
+            if $first; then
+                args+=("-source-path=$sp")
+                first=false
+            else
+                args+=("-source-path+=$sp")
+            fi
+        done
+    fi
+
+    # external-library-path
+    if [[ -n "$ext_libs" ]]; then
+        args+=("-external-library-path+=$ext_libs")
+    fi
+
+    # include-libraries
+    if [[ -n "$inc_libs" ]]; then
+        args+=("-include-libraries+=$inc_libs")
+    fi
+
+    java \
+        -Dsun.io.useCanonCaches=false -Xms32m -Xmx512m \
+        "-Droyalelib=$royale_home/frameworks" \
+        -jar "$royale_home/js/lib/compc.jar" \
+        -targets=SWF \
+        "-define+=CLIENT::LESTA,$is_lesta" \
+        "-define+=CLIENT::WG,$is_wg" \
+        -target-player=10.2 \
+        -swf-version=11 \
+        "-load-config=$config" \
+        -output "$output" \
+        "${args[@]}"
+}
+
+
+# ============================================================================
+# build_swf — compile an AS3 SWF via Apache Royale (mxmlc)
+# ============================================================================
+#
+# Args: same as build_swc, plus:
+#   --target    AS3 entry-point file
+#
+build_swf() {
+    local name="" output="" target="" source_path="" ext_libs="" inc_libs=""
+    local royale_home="" config="" flavor=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --name)              name="$2"; shift 2 ;;
+            --output)            output="$2"; shift 2 ;;
+            --target)            target="$2"; shift 2 ;;
+            --source-path)       source_path="$2"; shift 2 ;;
+            --external-library-path) ext_libs="$2"; shift 2 ;;
+            --include-libraries) inc_libs="$2"; shift 2 ;;
+            --royale-home)       royale_home="$2"; shift 2 ;;
+            --config)            config="$2"; shift 2 ;;
+            --flavor)            flavor="$2"; shift 2 ;;
+            *) echo "build_swf: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    local is_wg=false is_lesta=false
+    [[ "$flavor" == "wg" ]] && is_wg=true
+    [[ "$flavor" == "lesta" ]] && is_lesta=true
+
+    mkdir -p "$(dirname "$output")"
+
+    echo "    [SWF] $name"
+
+    local -a args=()
+
+    # source-path
+    if [[ -n "$source_path" ]]; then
+        local first=true
+        IFS=',' read -ra sp_arr <<< "$source_path"
+        for sp in "${sp_arr[@]}"; do
+            [[ -z "$sp" ]] && continue
+            if $first; then
+                args+=("-source-path=$sp")
+                first=false
+            else
+                args+=("-source-path+=$sp")
+            fi
+        done
+    fi
+
+    if [[ -n "$ext_libs" ]]; then
+        args+=("-external-library-path+=$ext_libs")
+    fi
+    if [[ -n "$inc_libs" ]]; then
+        args+=("-include-libraries+=$inc_libs")
+    fi
+
+    java \
+        -Dsun.io.useCanonCaches=false -Xms32m -Xmx512m \
+        "-Droyalelib=$royale_home/frameworks" \
+        -jar "$royale_home/js/lib/mxmlc.jar" \
+        -targets=SWF \
+        "-define+=CLIENT::LESTA,$is_lesta" \
+        "-define+=CLIENT::WG,$is_wg" \
+        -target-player=10.2 \
+        -swf-version=11 \
+        "-load-config=$config" \
+        -output "$output" \
+        "${args[@]}" \
+        "$target"
+}
+
+
+# ============================================================================
+# patch_swc — rabcdasm pipeline for SWC post-build patching
+# ============================================================================
+#
+# Args:
+#   --swc-file      Path to the .swc to patch (modified in-place)
+#   --patches       Comma-separated patch file paths
+#   --rabcdasm-dir  Directory containing rabcdasm binaries
+#
+patch_swc() {
+    local swc_file="" patches="" rabcdasm_dir=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --swc-file)     swc_file="$2"; shift 2 ;;
+            --patches)      patches="$2"; shift 2 ;;
+            --rabcdasm-dir) rabcdasm_dir="$2"; shift 2 ;;
+            *) echo "patch_swc: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    echo "    [SWC-PATCH] $(basename "$swc_file")"
+
+    local work_dir
+    work_dir="$(mktemp -d)"
+
+    unzip -q "$swc_file" -d "$work_dir"
+
+    local lib_swf="$work_dir/library.swf"
+    "$rabcdasm_dir/abcexport" "$lib_swf"
+    "$rabcdasm_dir/rabcdasm" "$work_dir/library-0.abc"
+
+    local dasm_dir="$work_dir/library-0"
+    IFS=',' read -ra patch_arr <<< "$patches"
+    for pf in "${patch_arr[@]}"; do
+        [[ -z "$pf" || ! -f "$pf" ]] && continue
+        echo "      patch: $(basename "$pf")"
+        (cd "$dasm_dir" && patch --binary -p1 -i "$pf")
+    done
+
+    "$rabcdasm_dir/rabcasm" "$dasm_dir/library-0.main.asasm"
+    "$rabcdasm_dir/abcreplace" "$lib_swf" 0 "$dasm_dir/library-0.main.abc"
+
+    # Repack SWC
+    rm "$swc_file"
+    (cd "$work_dir" && zip -q "$swc_file" library.swf catalog.xml)
+    rm -rf "$work_dir"
+}
+
+
+# ============================================================================
+# patch_wg_swf — rabcdasm pipeline for WG/Lesta SWF patching
+# ============================================================================
+#
+# Args:
+#   --input-swf     Source SWF (from game client)
+#   --output-swf    Patched output SWF path
+#   --patches       Comma-separated patch file paths (may be empty)
+#   --linkages      Comma-separated linkage names (may be empty)
+#   --rabcdasm-dir  Directory containing rabcdasm binaries
+#
+patch_wg_swf() {
+    local input_swf="" output_swf="" patches="" linkages="" rabcdasm_dir=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --input-swf)    input_swf="$2"; shift 2 ;;
+            --output-swf)   output_swf="$2"; shift 2 ;;
+            --patches)      patches="$2"; shift 2 ;;
+            --linkages)     linkages="$2"; shift 2 ;;
+            --rabcdasm-dir) rabcdasm_dir="$2"; shift 2 ;;
+            *) echo "patch_wg_swf: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    if [[ -z "$patches" && -z "$linkages" ]]; then
+        mkdir -p "$(dirname "$output_swf")"
+        cp "$input_swf" "$output_swf"
+        return 0
+    fi
+
+    echo "    [SWF-PATCH] $(basename "$input_swf")"
+
+    local work_dir
+    work_dir="$(mktemp -d)"
+    local base
+    base="$(basename "$input_swf" .swf)"
+
+    cp "$input_swf" "$work_dir/${base}.swf"
+    local work_swf="$work_dir/${base}.swf"
+
+    # Disassemble
+    "$rabcdasm_dir/abcexport" "$work_swf"
+    "$rabcdasm_dir/rabcdasm" "$work_dir/${base}-0.abc"
+
+    local dasm_dir="$work_dir/${base}-0"
+
+    # Apply patches
+    if [[ -n "$patches" ]]; then
+        IFS=',' read -ra patch_arr <<< "$patches"
+        for pf in "${patch_arr[@]}"; do
+            [[ -z "$pf" || ! -f "$pf" ]] && continue
+            echo "      patch: $(basename "$pf")"
+            (cd "$dasm_dir" && patch --binary -p1 -i "$pf")
+        done
+    fi
+
+    # Apply linkage conversions (trait const → trait slot)
+    if [[ -n "$linkages" ]]; then
+        local linkage_file="$dasm_dir/net/wg/data/constants/Linkages.class.asasm"
+        if [[ -f "$linkage_file" ]]; then
+            IFS=',' read -ra link_arr <<< "$linkages"
+            for lname in "${link_arr[@]}"; do
+                [[ -z "$lname" ]] && continue
+                if grep -q "trait const.*\"$lname\"" "$linkage_file"; then
+                    sed -i "s/trait const \(QName(PackageNamespace(\"\"), \"$lname\")\)/trait slot \1/" "$linkage_file"
+                    echo "      linkage: $lname -> slot"
+                else
+                    echo "      linkage: $lname (not found, skipping)"
+                fi
+            done
+        fi
+    fi
+
+    # Reassemble
+    "$rabcdasm_dir/rabcasm" "$dasm_dir/${base}-0.main.asasm"
+    "$rabcdasm_dir/abcreplace" "$work_swf" 0 "$dasm_dir/${base}-0.main.abc"
+
+    mkdir -p "$(dirname "$output_swf")"
+    cp "$work_swf" "$output_swf"
+    rm -rf "$work_dir"
+}
+
+
+# ============================================================================
+# compile_python_dir — compile .py files to .pyc via Python 2.7
+# ============================================================================
+#
+# Args:
+#   --src-dir   Source directory containing .py files
+#   --dst-dir   Destination directory for .pyc files
+#   --python27  Path to Python 2.7 interpreter
+#
+compile_python_dir() {
+    local src_dir="" dst_dir="" python27=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --src-dir)  src_dir="$2"; shift 2 ;;
+            --dst-dir)  dst_dir="$2"; shift 2 ;;
+            --python27) python27="$2"; shift 2 ;;
+            *) echo "compile_python_dir: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    mkdir -p "$dst_dir"
+    local count=0
+
+    while IFS= read -r -d '' pyfile; do
+        local rel="${pyfile#$src_dir/}"
+        local out_sub
+        out_sub="$(dirname "$rel")"
+        local target_dir="$dst_dir"
+        [[ "$out_sub" != "." ]] && target_dir="$dst_dir/$out_sub"
+        mkdir -p "$target_dir"
+
+        "$python27" -m py_compile "$pyfile"
+        mv "${pyfile}c" "$target_dir/"
+        count=$((count + 1))
+    done < <(find "$src_dir" -name "*.py" -print0)
+
+    echo "      $count .pyc files"
+}
+
+
+# ============================================================================
+# package_wotmod — zip a staging directory into a .wotmod/.mtmod
+# ============================================================================
+#
+# Args:
+#   --staging-dir  Directory containing meta.xml + res/ tree
+#   --output-file  Output .wotmod or .mtmod path
+#
+package_wotmod() {
+    local staging_dir="" output_file=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --staging-dir) staging_dir="$2"; shift 2 ;;
+            --output-file) output_file="$2"; shift 2 ;;
+            *) echo "package_wotmod: unknown arg: $1" >&2; exit 1 ;;
+        esac
+    done
+
+    mkdir -p "$(dirname "$output_file")"
+    (cd "$staging_dir" && zip -0 -X -r "$output_file" .)
+}
+
+
+# ============================================================================
+# Dispatch
+# ============================================================================
+
+cmd="${1:-}"
+[[ -z "$cmd" ]] && { echo "Usage: bash build_helpers.sh <command> [args...]" >&2; exit 1; }
+shift
+
+case "$cmd" in
+    build_swc)          build_swc "$@" ;;
+    build_swf)          build_swf "$@" ;;
+    patch_swc)          patch_swc "$@" ;;
+    patch_wg_swf)       patch_wg_swf "$@" ;;
+    compile_python_dir) compile_python_dir "$@" ;;
+    package_wotmod)     package_wotmod "$@" ;;
+    *) echo "Unknown command: $cmd" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Adds a reproducible Linux build system for XVM using Docker:

- **Dockerfile** — Ubuntu 20.04 + Java 11 + Python 2.7 + Apache Royale 0.9.12
- **build.py** — Data-driven Python orchestrator that reads the existing JSON configs (`actionscript.json`, `swfpatch.json`, `python.json`, `assets.json`, `component.json`) and delegates to `build_helpers.sh`
- **build_helpers.sh** — Bash function library for SWC/SWF compilation, `.pyc` compilation, and `.wotmod` packaging
- **.dockerignore** — Excludes `.git`, `~output`, build artifacts

### Usage

```bash
docker build --platform linux/amd64 -t xvm-build .
docker build --platform linux/amd64 --build-arg VERSION=13.0.0.0067 -t xvm-build .

# Extract .wotmod:
id=$(docker create xvm-build) && docker cp "$id:/build/~output/deploy/" ./out/ && docker rm "$id"
```

### Notes

- All files are purely additive — zero modifications to existing XVM source
- Compatible with both WG and Lesta flavors (`--build-arg FLAVOR=lesta`)
- Reads the same JSON config files used by the PowerShell build system